### PR TITLE
이력서 도메인 모델 및 보안 설정 추가

### DIFF
--- a/app/src/main/java/com/example/tech_interview_buddy/app/config/SecurityConfig.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/config/SecurityConfig.java
@@ -55,7 +55,9 @@ public class SecurityConfig {
                 
                 .requestMatchers("/api/v1/questions/**").authenticated()
                 .requestMatchers("/api/v1/answers/**").authenticated()
-                
+                .requestMatchers("/api/v1/resumes/**").authenticated()
+                .requestMatchers("/api/v1/notifications/**").authenticated()
+
                 .anyRequest().authenticated()
             )
             .userDetailsService(userDetailsService)

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/repository/resume/ResumeRepository.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/repository/resume/ResumeRepository.java
@@ -1,0 +1,7 @@
+package com.example.tech_interview_buddy.domain.repository.resume;
+
+import com.example.tech_interview_buddy.domain.resume.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/resume/Resume.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/resume/Resume.java
@@ -1,0 +1,134 @@
+package com.example.tech_interview_buddy.domain.resume;
+
+import com.example.tech_interview_buddy.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "resume")
+@EntityListeners(AuditingEntityListener.class)
+public class Resume {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "original_filename", nullable = false)
+    private String originalFilename;
+
+    @Column(name = "storage_key", nullable = false, unique = true)
+    private String storageKey;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(name = "mime_type", nullable = false)
+    private String mimeType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private ResumeStatus status = ResumeStatus.UPLOADED;
+
+    @Column(name = "extracted_text", columnDefinition = "LONGTEXT")
+    private String extractedText;
+
+    @Column(name = "summarized_text", columnDefinition = "TEXT")
+    private String summarizedText;
+
+    @Column(name = "review_data", columnDefinition = "LONGTEXT")
+    private String reviewData;
+
+    @Column(name = "review_summary", columnDefinition = "TEXT")
+    private String reviewSummary;
+
+    @Column(name = "failure_reason", columnDefinition = "TEXT")
+    private String failureReason;
+
+    @Column(name = "analysis_started_at")
+    private LocalDateTime analysisStartedAt;
+
+    @Column(name = "analysis_completed_at")
+    private LocalDateTime analysisCompletedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private Resume(User user, String originalFilename, Long fileSize, String mimeType, String storageKey) {
+        this.user = user;
+        this.originalFilename = originalFilename;
+        this.fileSize = fileSize;
+        this.mimeType = mimeType;
+        this.storageKey = storageKey;
+        this.status = ResumeStatus.UPLOADED;
+    }
+
+    public static Resume createUploaded(User user, String originalFilename, long fileSize, String mimeType, String storageKey) {
+        return Resume.builder()
+            .user(user)
+            .originalFilename(originalFilename)
+            .fileSize(fileSize)
+            .mimeType(mimeType)
+            .storageKey(storageKey)
+            .build();
+    }
+
+    public void updateStorageKey(String storageKey) {
+        this.storageKey = storageKey;
+    }
+
+    public void markProcessing(LocalDateTime startedAt) {
+        this.status = ResumeStatus.PROCESSING;
+        this.analysisStartedAt = startedAt;
+        this.failureReason = null;
+    }
+
+    public void markCompleted(LocalDateTime completedAt) {
+        this.status = ResumeStatus.DONE;
+        this.analysisCompletedAt = completedAt;
+    }
+
+    public void markFailed(String reason, LocalDateTime completedAt) {
+        this.status = ResumeStatus.FAILED;
+        this.failureReason = reason;
+        this.analysisCompletedAt = completedAt;
+    }
+
+    public void saveExtractedText(String extractedText, String summarizedText) {
+        this.extractedText = extractedText;
+        this.summarizedText = summarizedText;
+    }
+
+    public void saveReviewResult(String reviewData, String reviewSummary) {
+        this.reviewData = reviewData;
+        this.reviewSummary = reviewSummary;
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/resume/ResumeSection.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/resume/ResumeSection.java
@@ -1,0 +1,14 @@
+package com.example.tech_interview_buddy.domain.resume;
+
+/**
+ * Logical resume sections used to anchor AI feedback.
+ */
+public enum ResumeSection {
+    SUMMARY,
+    SKILLS,
+    EXPERIENCE,
+    PROJECT,
+    EDUCATION,
+    ETC,
+    GLOBAL
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/resume/ResumeStatus.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/resume/ResumeStatus.java
@@ -1,0 +1,8 @@
+package com.example.tech_interview_buddy.domain.resume;
+
+public enum ResumeStatus {
+    UPLOADED,
+    PROCESSING,
+    DONE,
+    FAILED
+}

--- a/common/src/main/java/com/example/tech_interview_buddy/common/domain/Category.java
+++ b/common/src/main/java/com/example/tech_interview_buddy/common/domain/Category.java
@@ -9,5 +9,6 @@ public enum Category {
     SYSTEM_DESIGN,
     NETWORK,
     SECURITY,
-    DEVOPS
+    DEVOPS,
+    BEHAVIORAL
 }

--- a/common/src/main/java/com/example/tech_interview_buddy/common/domain/Difficulty.java
+++ b/common/src/main/java/com/example/tech_interview_buddy/common/domain/Difficulty.java
@@ -1,0 +1,10 @@
+package com.example.tech_interview_buddy.common.domain;
+
+/**
+ * Shared difficulty scale for interview questions.
+ */
+public enum Difficulty {
+    EASY,
+    MEDIUM,
+    HARD
+}


### PR DESCRIPTION
## Summary
- `common` 모듈에 `BEHAVIORAL` 카테고리, `Difficulty` enum 추가
- 이력서 도메인 모델 생성: `Resume` 엔티티, `ResumeStatus`/`ResumeSection` enum, `ResumeRepository`
- `SecurityConfig`에 `/api/v1/resumes/**`, `/api/v1/notifications/**` 인증 필수 설정 추가

## Changes
- [x] 1.1 `Category` enum에 `BEHAVIORAL` 값 추가
- [x] 1.2 `Difficulty` enum 신규 생성 (`EASY`, `MEDIUM`, `HARD`)
- [x] 1.3 `ResumeStatus` enum 생성
- [x] 1.4 `ResumeSection` enum 생성
- [x] 1.5 `Resume` 엔티티 생성
- [x] 1.6 `ResumeRepository` 생성
- [x] 1.7 이력서 API 인증 필수 설정
- [x] 1.8 알림 API 인증 필수 설정
