### PR TITLE
이력서 파일 업로드 및 텍스트 추출 기능 구현

### DIFF
--- a/app/src/main/java/com/example/tech_interview_buddy/app/config/S3RequestFactory.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/config/S3RequestFactory.java
@@ -3,6 +3,7 @@ package com.example.tech_interview_buddy.app.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
@@ -17,6 +18,13 @@ public class S3RequestFactory {
             .key(key)
             .contentType(contentType)
             .contentLength(contentLength)
+            .build();
+    }
+
+    public GetObjectRequest getRequest(String key) {
+        return GetObjectRequest.builder()
+            .bucket(properties.getBucketName())
+            .key(key)
             .build();
     }
 

--- a/app/src/main/java/com/example/tech_interview_buddy/app/controller/ResumeController.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/controller/ResumeController.java
@@ -1,0 +1,32 @@
+package com.example.tech_interview_buddy.app.controller;
+
+import com.example.tech_interview_buddy.app.dto.response.resume.ResumeUploadResponse;
+import com.example.tech_interview_buddy.app.service.resume.ResumeUploadService;
+import com.example.tech_interview_buddy.domain.User;
+import com.example.tech_interview_buddy.domain.resume.Resume;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/resumes")
+@RequiredArgsConstructor
+public class ResumeController {
+
+    private final ResumeUploadService resumeUploadService;
+
+    @PostMapping
+    public ResponseEntity<ResumeUploadResponse> upload(
+            @AuthenticationPrincipal User user,
+            @RequestParam("file") MultipartFile file) {
+        Resume resume = resumeUploadService.upload(user, file);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ResumeUploadResponse.from(resume));
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/resume/ResumeUploadResponse.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/resume/ResumeUploadResponse.java
@@ -1,0 +1,22 @@
+package com.example.tech_interview_buddy.app.dto.response.resume;
+
+import com.example.tech_interview_buddy.domain.resume.Resume;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResumeUploadResponse {
+
+    private Long resumeId;
+    private String filename;
+    private String status;
+
+    public static ResumeUploadResponse from(Resume resume) {
+        return ResumeUploadResponse.builder()
+            .resumeId(resume.getId())
+            .filename(resume.getOriginalFilename())
+            .status(resume.getStatus().name())
+            .build();
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/DocxTextExtractor.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/DocxTextExtractor.java
@@ -1,0 +1,22 @@
+package com.example.tech_interview_buddy.app.service.resume;
+
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class DocxTextExtractor {
+
+    public String extract(InputStream inputStream) throws IOException {
+        try (XWPFDocument document = new XWPFDocument(inputStream);
+            XWPFWordExtractor extractor = new XWPFWordExtractor(document)) {
+            String text = extractor.getText();
+            log.info("DOCX text extracted - {} characters", text.length());
+            return text.trim();
+        }
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/PdfTextExtractor.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/PdfTextExtractor.java
@@ -1,0 +1,22 @@
+package com.example.tech_interview_buddy.app.service.resume;
+
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PdfTextExtractor {
+
+    public String extract(InputStream inputStream) throws IOException {
+        try (PDDocument document = PDDocument.load(inputStream)) {
+            PDFTextStripper stripper = new PDFTextStripper();
+            String text = stripper.getText(document);
+            log.info("PDF text extracted - {} characters", text.length());
+            return text.trim();
+        }
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeFileValidator.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeFileValidator.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Component
 public class ResumeFileValidator {
 
+    private static final int MAX_RESUME_COUNT = 5;
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
     private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
         "application/pdf",
@@ -31,6 +32,12 @@ public class ResumeFileValidator {
     private void validateFileSize(MultipartFile file) {
         if (file.getSize() > MAX_FILE_SIZE) {
             throw new IllegalArgumentException("파일 크기는 10MB 이하만 허용됩니다.");
+        }
+    }
+
+    public void validateResumeCount(long currentCount) {
+        if (currentCount >= MAX_RESUME_COUNT) {
+            throw new IllegalStateException("이력서는 최대 " + MAX_RESUME_COUNT + "개까지 업로드할 수 있습니다.");
         }
     }
 }

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeFileValidator.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeFileValidator.java
@@ -1,0 +1,36 @@
+package com.example.tech_interview_buddy.app.service.resume;
+
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class ResumeFileValidator {
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+    private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    );
+
+    public void validate(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+        validateFileType(file);
+        validateFileSize(file);
+    }
+
+    private void validateFileType(MultipartFile file) {
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_MIME_TYPES.contains(contentType)) {
+            throw new IllegalArgumentException("PDF 또는 DOCX 파일만 업로드할 수 있습니다.");
+        }
+    }
+
+    private void validateFileSize(MultipartFile file) {
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("파일 크기는 10MB 이하만 허용됩니다.");
+        }
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeUploadService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeUploadService.java
@@ -1,0 +1,42 @@
+package com.example.tech_interview_buddy.app.service.resume;
+
+import com.example.tech_interview_buddy.domain.User;
+import com.example.tech_interview_buddy.domain.repository.resume.ResumeRepository;
+import com.example.tech_interview_buddy.domain.resume.Resume;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ResumeUploadService {
+
+    private final ResumeFileValidator fileValidator;
+    private final ResumeStorageService storageService;
+    private final ResumeRepository resumeRepository;
+
+    @Transactional
+    public Resume upload(User user, MultipartFile file) {
+        fileValidator.validate(file);
+
+        Resume resume = resumeRepository.save(
+            Resume.createUploaded(
+                user,
+                file.getOriginalFilename(),
+                file.getSize(),
+                file.getContentType(),
+                "temp"
+            )
+        );
+
+        String storageKey = storageService.buildStorageKey(user.getId(), resume.getId(), file.getOriginalFilename());
+        storageService.uploadFile(file, storageKey);
+        resume.updateStorageKey(storageKey);
+
+        log.info("Resume uploaded - id: {}, userId: {}, filename: {}", resume.getId(), user.getId(), file.getOriginalFilename());
+        return resume;
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeUploadService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeUploadService.java
@@ -21,6 +21,7 @@ public class ResumeUploadService {
     @Transactional
     public Resume upload(User user, MultipartFile file) {
         fileValidator.validate(file);
+        fileValidator.validateResumeCount(resumeRepository.countByUserId(user.getId()));
 
         Resume resume = resumeRepository.save(
             Resume.createUploaded(

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/TextExtractionException.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/TextExtractionException.java
@@ -1,0 +1,12 @@
+package com.example.tech_interview_buddy.app.service.resume;
+
+public class TextExtractionException extends RuntimeException {
+
+    public TextExtractionException(String message) {
+        super(message);
+    }
+
+    public TextExtractionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/TextExtractionService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/TextExtractionService.java
@@ -1,0 +1,51 @@
+package com.example.tech_interview_buddy.app.service.resume;
+
+import java.io.InputStream;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TextExtractionService {
+
+    private static final int MAX_TEXT_LENGTH = 50_000;
+    private static final Set<String> SUPPORTED_MIME_TYPES = Set.of(
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    );
+
+    private final PdfTextExtractor pdfTextExtractor;
+    private final DocxTextExtractor docxTextExtractor;
+
+    public String extract(InputStream inputStream, String mimeType) {
+        if (!SUPPORTED_MIME_TYPES.contains(mimeType)) {
+            throw new TextExtractionException("지원하지 않는 파일 형식입니다: " + mimeType);
+        }
+
+        String text;
+        try {
+            text = switch (mimeType) {
+                case "application/pdf" -> pdfTextExtractor.extract(inputStream);
+                case "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ->
+                    docxTextExtractor.extract(inputStream);
+                default -> throw new IllegalStateException("Unreachable: unsupported mimeType=" + mimeType);
+            };
+        } catch (Exception e) {
+            throw new TextExtractionException("파일에서 텍스트를 추출하는 중 오류가 발생했습니다.", e);
+        }
+
+        if (text == null || text.isBlank()) {
+            throw new TextExtractionException("텍스트를 추출할 수 없는 파일입니다. (이미지 기반 PDF 등)");
+        }
+
+        if (text.length() > MAX_TEXT_LENGTH) {
+            throw new TextExtractionException("텍스트가 너무 많은 파일입니다. 이력서 길이를 줄인 후 업로드해 주세요.");
+        }
+
+        log.info("Text extracted - {} characters, mimeType: {}", text.length(), mimeType);
+        return text;
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/repository/resume/ResumeRepository.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/repository/resume/ResumeRepository.java
@@ -4,4 +4,6 @@ import com.example.tech_interview_buddy.domain.resume.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
+
+    long countByUserId(Long userId);
 }

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/AnswerEvaluationPromptTemplate.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/AnswerEvaluationPromptTemplate.java
@@ -93,6 +93,7 @@ public class AnswerEvaluationPromptTemplate {
             case NETWORK -> "네트워크";
             case SECURITY -> "보안";
             case DEVOPS -> "DevOps";
+            case BEHAVIORAL -> "행동 면접";
         };
     }
 }

--- a/app/src/test/groovy/com/example/tech_interview_buddy/app/service/resume/DocxTextExtractorSpec.groovy
+++ b/app/src/test/groovy/com/example/tech_interview_buddy/app/service/resume/DocxTextExtractorSpec.groovy
@@ -1,0 +1,63 @@
+package com.example.tech_interview_buddy.app.service.resume
+
+import org.apache.poi.xwpf.usermodel.XWPFDocument
+import spock.lang.Specification
+import spock.lang.Subject
+
+class DocxTextExtractorSpec extends Specification {
+
+    @Subject
+    def extractor = new DocxTextExtractor()
+
+    def "텍스트가 포함된 DOCX에서 텍스트를 추출한다"() {
+        given:
+        def docxBytes = createDocxWithText("이력서 내용입니다.")
+        def inputStream = new ByteArrayInputStream(docxBytes)
+
+        when:
+        def result = extractor.extract(inputStream)
+
+        then:
+        result.contains("이력서 내용입니다.")
+    }
+
+    def "빈 DOCX에서는 빈 텍스트를 반환한다"() {
+        given:
+        def docxBytes = createEmptyDocx()
+        def inputStream = new ByteArrayInputStream(docxBytes)
+
+        when:
+        def result = extractor.extract(inputStream)
+
+        then:
+        result.isBlank()
+    }
+
+    def "잘못된 데이터를 넣으면 예외가 발생한다"() {
+        given:
+        def inputStream = new ByteArrayInputStream("not a docx".getBytes())
+
+        when:
+        extractor.extract(inputStream)
+
+        then:
+        thrown(Exception)
+    }
+
+    private byte[] createDocxWithText(String text) {
+        def baos = new ByteArrayOutputStream()
+        def document = new XWPFDocument()
+        document.createParagraph().createRun().setText(text)
+        document.write(baos)
+        document.close()
+        return baos.toByteArray()
+    }
+
+    private byte[] createEmptyDocx() {
+        def baos = new ByteArrayOutputStream()
+        def document = new XWPFDocument()
+        document.write(baos)
+        document.close()
+        return baos.toByteArray()
+    }
+}

--- a/app/src/test/groovy/com/example/tech_interview_buddy/app/service/resume/PdfTextExtractorSpec.groovy
+++ b/app/src/test/groovy/com/example/tech_interview_buddy/app/service/resume/PdfTextExtractorSpec.groovy
@@ -1,0 +1,77 @@
+package com.example.tech_interview_buddy.app.service.resume
+
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.PDPageContentStream
+import org.apache.pdfbox.pdmodel.font.PDType1Font
+import spock.lang.Specification
+import spock.lang.Subject
+
+class PdfTextExtractorSpec extends Specification {
+
+    @Subject
+    def extractor = new PdfTextExtractor()
+
+    def "텍스트가 포함된 PDF에서 텍스트를 추출한다"() {
+        given:
+        def pdfBytes = createPdfWithText("Resume text content")
+        def inputStream = new ByteArrayInputStream(pdfBytes)
+
+        when:
+        def result = extractor.extract(inputStream)
+
+        then:
+        result.contains("Resume text content")
+    }
+
+    def "빈 PDF에서는 빈 텍스트를 반환한다"() {
+        given:
+        def pdfBytes = createEmptyPdf()
+        def inputStream = new ByteArrayInputStream(pdfBytes)
+
+        when:
+        def result = extractor.extract(inputStream)
+
+        then:
+        result.isBlank()
+    }
+
+    def "잘못된 데이터를 넣으면 IOException이 발생한다"() {
+        given:
+        def inputStream = new ByteArrayInputStream("not a pdf".getBytes())
+
+        when:
+        extractor.extract(inputStream)
+
+        then:
+        thrown(IOException)
+    }
+
+    private byte[] createPdfWithText(String text) {
+        def baos = new ByteArrayOutputStream()
+        def document = new PDDocument()
+        def page = new PDPage()
+        document.addPage(page)
+
+        def contentStream = new PDPageContentStream(document, page)
+        contentStream.beginText()
+        contentStream.setFont(PDType1Font.HELVETICA, 12)
+        contentStream.newLineAtOffset(50, 700)
+        contentStream.showText(text)
+        contentStream.endText()
+        contentStream.close()
+
+        document.save(baos)
+        document.close()
+        return baos.toByteArray()
+    }
+
+    private byte[] createEmptyPdf() {
+        def baos = new ByteArrayOutputStream()
+        def document = new PDDocument()
+        document.addPage(new PDPage())
+        document.save(baos)
+        document.close()
+        return baos.toByteArray()
+    }
+}

--- a/app/src/test/groovy/com/example/tech_interview_buddy/app/service/resume/TextExtractionServiceSpec.groovy
+++ b/app/src/test/groovy/com/example/tech_interview_buddy/app/service/resume/TextExtractionServiceSpec.groovy
@@ -1,0 +1,109 @@
+package com.example.tech_interview_buddy.app.service.resume
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TextExtractionServiceSpec extends Specification {
+
+    def pdfTextExtractor = Mock(PdfTextExtractor)
+    def docxTextExtractor = Mock(DocxTextExtractor)
+
+    @Subject
+    def service = new TextExtractionService(pdfTextExtractor, docxTextExtractor)
+
+    def "PDF 파일에서 텍스트를 정상 추출한다"() {
+        given:
+        def inputStream = Mock(InputStream)
+        pdfTextExtractor.extract(inputStream) >> "이력서 내용입니다"
+
+        when:
+        def result = service.extract(inputStream, "application/pdf")
+
+        then:
+        result == "이력서 내용입니다"
+    }
+
+    def "DOCX 파일에서 텍스트를 정상 추출한다"() {
+        given:
+        def inputStream = Mock(InputStream)
+        def mimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        docxTextExtractor.extract(inputStream) >> "DOCX 이력서 내용"
+
+        when:
+        def result = service.extract(inputStream, mimeType)
+
+        then:
+        result == "DOCX 이력서 내용"
+    }
+
+    def "지원하지 않는 파일 형식이면 예외를 던진다"() {
+        given:
+        def inputStream = Mock(InputStream)
+
+        when:
+        service.extract(inputStream, "image/png")
+
+        then:
+        def e = thrown(TextExtractionException)
+        e.message.contains("지원하지 않는 파일 형식")
+    }
+
+    def "추출된 텍스트가 비어있으면 예외를 던진다 - #scenario"() {
+        given:
+        def inputStream = Mock(InputStream)
+        pdfTextExtractor.extract(inputStream) >> text
+
+        when:
+        service.extract(inputStream, "application/pdf")
+
+        then:
+        def e = thrown(TextExtractionException)
+        e.message.contains("텍스트를 추출할 수 없는 파일")
+
+        where:
+        scenario       | text
+        "null"         | null
+        "빈 문자열"     | ""
+        "공백만 있음"   | "   "
+    }
+
+    def "텍스트가 50,000자를 초과하면 예외를 던진다"() {
+        given:
+        def inputStream = Mock(InputStream)
+        pdfTextExtractor.extract(inputStream) >> "가" * 50_001
+
+        when:
+        service.extract(inputStream, "application/pdf")
+
+        then:
+        def e = thrown(TextExtractionException)
+        e.message.contains("텍스트가 너무 많은 파일")
+    }
+
+    def "텍스트가 정확히 50,000자이면 정상 처리된다"() {
+        given:
+        def inputStream = Mock(InputStream)
+        def text = "가" * 50_000
+        pdfTextExtractor.extract(inputStream) >> text
+
+        when:
+        def result = service.extract(inputStream, "application/pdf")
+
+        then:
+        result == text
+    }
+
+    def "IOException 발생 시 TextExtractionException으로 변환한다"() {
+        given:
+        def inputStream = Mock(InputStream)
+        pdfTextExtractor.extract(inputStream) >> { throw new IOException("읽기 실패") }
+
+        when:
+        service.extract(inputStream, "application/pdf")
+
+        then:
+        def e = thrown(TextExtractionException)
+        e.message.contains("텍스트를 추출하는 중 오류")
+        e.cause instanceof IOException
+    }
+}


### PR DESCRIPTION
## Summary
이력서 파일을 S3에 업로드하고, 업로드된 PDF/DOCX 파일에서 텍스트를 추출하는 기능 구현

## Changes
- 이력서 파일 업로드 API (`POST /api/v1/resumes`)
- 파일 유효성 검증 (PDF/DOCX만 허용, 10MB 이하, 사용자당 5개 제한)
- PDFBox 기반 PDF 텍스트 추출
- Apache POI 기반 DOCX 텍스트 추출
- 텍스트 추출 실패 시 예외 처리

Closes #13 
