### PR TITLE
이력서 분석완료 알림 기능 구현

### DIFF
--- a/app/src/main/java/com/example/tech_interview_buddy/app/config/SecurityConfig.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/config/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://127.0.0.1:5173"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);
 

--- a/app/src/main/java/com/example/tech_interview_buddy/app/controller/NotificationController.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/controller/NotificationController.java
@@ -1,0 +1,49 @@
+package com.example.tech_interview_buddy.app.controller;
+
+import com.example.tech_interview_buddy.app.dto.response.NotificationResponse;
+import com.example.tech_interview_buddy.app.service.notification.NotificationQueryService;
+import com.example.tech_interview_buddy.app.service.notification.NotificationReadService;
+import com.example.tech_interview_buddy.domain.User;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationQueryService notificationQueryService;
+    private final NotificationReadService notificationReadService;
+
+    @GetMapping
+    public ResponseEntity<List<NotificationResponse>> list(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(notificationQueryService.listNotifications(user.getId()));
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<Map<String, Long>> unreadCount(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(Map.of("count", notificationQueryService.countUnread(user.getId())));
+    }
+
+    @PatchMapping("/{id}/read")
+    public ResponseEntity<Void> markRead(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long id) {
+        notificationReadService.markRead(id, user.getId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<Void> markAllRead(@AuthenticationPrincipal User user) {
+        notificationReadService.markAllRead(user.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/NotificationResponse.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/NotificationResponse.java
@@ -1,0 +1,27 @@
+package com.example.tech_interview_buddy.app.dto.response;
+
+import com.example.tech_interview_buddy.domain.Notification;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationResponse {
+
+    private Long notificationId;
+    private String message;
+    private boolean read;
+    private LocalDateTime createdAt;
+    private Long resumeId;
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+            .notificationId(notification.getId())
+            .message(notification.getMessage())
+            .read(notification.isRead())
+            .createdAt(notification.getCreatedAt())
+            .resumeId(notification.getResumeId())
+            .build();
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/resume/ResumeDetailResponse.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/resume/ResumeDetailResponse.java
@@ -20,6 +20,8 @@ public class ResumeDetailResponse {
     private LocalDateTime analysisCompletedAt;
 
     private String presignedUrl;
+    private String extractedText;
+    private String markdownText;
 
     private String statusMessage;
 

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/notification/NotificationCreationService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/notification/NotificationCreationService.java
@@ -1,0 +1,31 @@
+package com.example.tech_interview_buddy.app.service.notification;
+
+import com.example.tech_interview_buddy.domain.Notification;
+import com.example.tech_interview_buddy.domain.repository.NotificationRepository;
+import com.example.tech_interview_buddy.domain.resume.Resume;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationCreationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public void notifySuccess(Resume resume) {
+        String message = String.format("이력서 '%s' 분석이 완료되었습니다", resume.getOriginalFilename());
+        notificationRepository.save(Notification.create(resume.getUser(), message, resume.getId()));
+        log.info("Success notification created for resumeId={}", resume.getId());
+    }
+
+    @Transactional
+    public void notifyFailure(Resume resume) {
+        String message = String.format("이력서 '%s' 분석에 실패했습니다", resume.getOriginalFilename());
+        notificationRepository.save(Notification.create(resume.getUser(), message, resume.getId()));
+        log.info("Failure notification created for resumeId={}", resume.getId());
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/notification/NotificationQueryService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/notification/NotificationQueryService.java
@@ -1,0 +1,29 @@
+package com.example.tech_interview_buddy.app.service.notification;
+
+import com.example.tech_interview_buddy.app.dto.response.NotificationResponse;
+import com.example.tech_interview_buddy.domain.repository.NotificationRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationQueryService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> listNotifications(Long userId) {
+        return notificationRepository.findByUserIdOrderByCreatedAtDesc(userId)
+            .stream()
+            .map(NotificationResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public long countUnread(Long userId) {
+        return notificationRepository.countByUserIdAndReadFalse(userId);
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/notification/NotificationReadService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/notification/NotificationReadService.java
@@ -1,0 +1,34 @@
+package com.example.tech_interview_buddy.app.service.notification;
+
+import com.example.tech_interview_buddy.domain.Notification;
+import com.example.tech_interview_buddy.domain.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationReadService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public void markRead(Long notificationId, Long userId) {
+        Notification notification = notificationRepository.findById(notificationId)
+            .orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."));
+
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "알림에 접근할 수 없습니다.");
+        }
+
+        notification.markRead();
+    }
+
+    @Transactional
+    public void markAllRead(Long userId) {
+        notificationRepository.markAllReadByUserId(userId);
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeAnalysisOrchestrator.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeAnalysisOrchestrator.java
@@ -5,6 +5,7 @@ import com.example.tech_interview_buddy.domain.resume.Resume;
 import com.example.tech_interview_buddy.app.service.notification.NotificationCreationService;
 import com.example.tech_interview_buddy.domain.service.resume.ResumeAiQuestionService;
 import com.example.tech_interview_buddy.domain.service.resume.ResumeAiReviewService;
+import com.example.tech_interview_buddy.domain.service.resume.ResumeMarkdownService;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.concurrent.ConcurrentHashMap;
@@ -24,6 +25,7 @@ public class ResumeAnalysisOrchestrator {
     private final TextExtractionService textExtractionService;
     private final ResumeAiReviewService aiReviewService;
     private final ResumeAiQuestionService aiQuestionService;
+    private final ResumeMarkdownService markdownService;
     private final NotificationCreationService notificationCreationService;
 
     private final ConcurrentHashMap<Long, Semaphore> userSemaphores = new ConcurrentHashMap<>();
@@ -67,6 +69,13 @@ public class ResumeAnalysisOrchestrator {
 
             resume.markProcessing(LocalDateTime.now());
             resumeRepository.save(resume);
+
+            try {
+                markdownService.convertAndSave(resume);
+            } catch (Exception e) {
+                log.warn("Markdown conversion failed for resumeId={}, continuing pipeline: {}",
+                        resume.getId(), e.getMessage());
+            }
 
             aiReviewService.generateAndSave(resume);
 

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeAnalysisOrchestrator.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeAnalysisOrchestrator.java
@@ -2,6 +2,7 @@ package com.example.tech_interview_buddy.app.service.resume;
 
 import com.example.tech_interview_buddy.domain.repository.resume.ResumeRepository;
 import com.example.tech_interview_buddy.domain.resume.Resume;
+import com.example.tech_interview_buddy.app.service.notification.NotificationCreationService;
 import com.example.tech_interview_buddy.domain.service.resume.ResumeAiQuestionService;
 import com.example.tech_interview_buddy.domain.service.resume.ResumeAiReviewService;
 import java.io.InputStream;
@@ -23,6 +24,7 @@ public class ResumeAnalysisOrchestrator {
     private final TextExtractionService textExtractionService;
     private final ResumeAiReviewService aiReviewService;
     private final ResumeAiQuestionService aiQuestionService;
+    private final NotificationCreationService notificationCreationService;
 
     private final ConcurrentHashMap<Long, Semaphore> userSemaphores = new ConcurrentHashMap<>();
 
@@ -73,16 +75,19 @@ public class ResumeAnalysisOrchestrator {
             resume.markCompleted(LocalDateTime.now());
             resumeRepository.save(resume);
 
+            notificationCreationService.notifySuccess(resume);
             log.info("Analysis completed for resumeId={}", resume.getId());
 
         } catch (TextExtractionException e) {
             log.warn("Text extraction failed for resumeId={}: {}", resume.getId(), e.getMessage());
             resume.markFailed(e.getMessage(), LocalDateTime.now());
             resumeRepository.save(resume);
+            notificationCreationService.notifyFailure(resume);
         } catch (Exception e) {
             log.error("Analysis failed for resumeId={}", resume.getId(), e);
             resume.markFailed("분석 중 오류가 발생했습니다.", LocalDateTime.now());
             resumeRepository.save(resume);
+            notificationCreationService.notifyFailure(resume);
         }
     }
 }

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeAnalysisOrchestrator.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeAnalysisOrchestrator.java
@@ -70,12 +70,7 @@ public class ResumeAnalysisOrchestrator {
             resume.markProcessing(LocalDateTime.now());
             resumeRepository.save(resume);
 
-            try {
-                markdownService.convertAndSave(resume);
-            } catch (Exception e) {
-                log.warn("Markdown conversion failed for resumeId={}, continuing pipeline: {}",
-                        resume.getId(), e.getMessage());
-            }
+            markdownService.convertAndSave(resume);
 
             aiReviewService.generateAndSave(resume);
 

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDeleteService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDeleteService.java
@@ -1,5 +1,6 @@
 package com.example.tech_interview_buddy.app.service.resume;
 
+import com.example.tech_interview_buddy.domain.repository.NotificationRepository;
 import com.example.tech_interview_buddy.domain.repository.resume.ResumeQuestionRepository;
 import com.example.tech_interview_buddy.domain.repository.resume.ResumeRepository;
 import com.example.tech_interview_buddy.domain.resume.Resume;
@@ -18,6 +19,7 @@ public class ResumeDeleteService {
 
     private final ResumeRepository resumeRepository;
     private final ResumeQuestionRepository questionRepository;
+    private final NotificationRepository notificationRepository;
     private final ResumeStorageService storageService;
 
     @Transactional
@@ -31,6 +33,7 @@ public class ResumeDeleteService {
         }
 
         questionRepository.deleteByResumeId(resumeId);
+        notificationRepository.deleteByResumeId(resumeId);
         storageService.deleteFile(resume.getStorageKey());
         resumeRepository.delete(resume);
 

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDetailService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDetailService.java
@@ -58,6 +58,8 @@ public class ResumeDetailService {
             .uploadedAt(resume.getCreatedAt())
             .analysisCompletedAt(resume.getAnalysisCompletedAt())
             .presignedUrl(presignedUrl)
+            .extractedText(resume.getExtractedText())
+            .markdownText(resume.getSummarizedText())
             .statusMessage(statusMessage)
             .review(review)
             .questions(questions)

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/Notification.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/Notification.java
@@ -1,0 +1,67 @@
+package com.example.tech_interview_buddy.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "notification")
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    @Column(nullable = false)
+    private boolean read = false;
+
+    @Column(name = "resume_id")
+    private Long resumeId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private Notification(User user, String message, Long resumeId) {
+        this.user = user;
+        this.message = message;
+        this.resumeId = resumeId;
+        this.read = false;
+    }
+
+    public static Notification create(User user, String message, Long resumeId) {
+        return Notification.builder()
+            .user(user)
+            .message(message)
+            .resumeId(resumeId)
+            .build();
+    }
+
+    public void markRead() {
+        this.read = true;
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/Notification.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/Notification.java
@@ -35,7 +35,7 @@ public class Notification {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String message;
 
-    @Column(nullable = false)
+    @Column(name = "is_read", nullable = false)
     private boolean read = false;
 
     @Column(name = "resume_id")

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/repository/NotificationRepository.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/repository/NotificationRepository.java
@@ -1,0 +1,20 @@
+package com.example.tech_interview_buddy.domain.repository;
+
+import com.example.tech_interview_buddy.domain.Notification;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    long countByUserIdAndReadFalse(Long userId);
+
+    void deleteByResumeId(Long resumeId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.read = true WHERE n.user.id = :userId AND n.read = false")
+    int markAllReadByUserId(Long userId);
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/ai/AiAdapter.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/ai/AiAdapter.java
@@ -2,4 +2,8 @@ package com.example.tech_interview_buddy.domain.service.ai;
 
 public interface AiAdapter {
     String sendPrompt(String prompt);
+
+    default String sendPrompt(String prompt, int maxTokens) {
+        return sendPrompt(prompt);
+    }
 }

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/ai/OpenAIAdapter.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/ai/OpenAIAdapter.java
@@ -32,13 +32,18 @@ public class OpenAIAdapter implements AiAdapter {
 
     @Override
     public String sendPrompt(String prompt) {
+        return sendPrompt(prompt, MAX_TOKENS);
+    }
+
+    @Override
+    public String sendPrompt(String prompt, int maxTokens) {
         if (!openAiConfig.isConfigured()) {
             log.warn("OpenAI API key is not configured. Skipping API call.");
             return null;
         }
 
         try {
-            ResponseEntity<ChatCompletionResponse> response = callOpenAiApi(prompt);
+            ResponseEntity<ChatCompletionResponse> response = callOpenAiApi(prompt, maxTokens);
             return extractContent(response);
         } catch (HttpClientErrorException e) {
             handleHttpClientError(e);
@@ -52,10 +57,10 @@ public class OpenAIAdapter implements AiAdapter {
         }
     }
 
-    private ResponseEntity<ChatCompletionResponse> callOpenAiApi(String prompt) {
+    private ResponseEntity<ChatCompletionResponse> callOpenAiApi(String prompt, int maxTokens) {
         String url = openAiConfig.getApiUrl();
         HttpHeaders headers = createHeaders();
-        Map<String, Object> requestBody = createRequestBody(prompt);
+        Map<String, Object> requestBody = createRequestBody(prompt, maxTokens);
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
 
         log.debug("Calling OpenAI API: {}", url);
@@ -81,13 +86,13 @@ public class OpenAIAdapter implements AiAdapter {
         return headers;
     }
 
-    private Map<String, Object> createRequestBody(String prompt) {
+    private Map<String, Object> createRequestBody(String prompt, int maxTokens) {
         return Map.of(
                 "model", MODEL,
                 "messages", List.of(
                         Map.of("role", "user", "content", prompt)),
                 "temperature", TEMPERATURE,
-                "max_tokens", MAX_TOKENS);
+                "max_tokens", maxTokens);
     }
 
     private String extractContent(ResponseEntity<ChatCompletionResponse> response) {

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/ai/OpenAIAdapter.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/ai/OpenAIAdapter.java
@@ -27,7 +27,7 @@ public class OpenAIAdapter implements AiAdapter {
     private final RestTemplate restTemplate;
 
     private static final String MODEL = "gpt-4o-mini";
-    private static final double TEMPERATURE = 0.3;
+    private static final double TEMPERATURE = 0.1;
     private static final int MAX_TOKENS = 1000;
 
     @Override
@@ -65,8 +65,7 @@ public class OpenAIAdapter implements AiAdapter {
                 url,
                 HttpMethod.POST,
                 request,
-                ChatCompletionResponse.class
-        );
+                ChatCompletionResponse.class);
 
         log.debug("OpenAI API response status: {}", response.getStatusCode());
         log.debug("OpenAI API response body: {}", response.getBody());
@@ -86,11 +85,9 @@ public class OpenAIAdapter implements AiAdapter {
         return Map.of(
                 "model", MODEL,
                 "messages", List.of(
-                        Map.of("role", "user", "content", prompt)
-                ),
+                        Map.of("role", "user", "content", prompt)),
                 "temperature", TEMPERATURE,
-                "max_tokens", MAX_TOKENS
-        );
+                "max_tokens", MAX_TOKENS);
     }
 
     private String extractContent(ResponseEntity<ChatCompletionResponse> response) {
@@ -99,7 +96,7 @@ public class OpenAIAdapter implements AiAdapter {
             log.warn("Empty response from OpenAI API");
             return null;
         }
-        
+
         List<ChatCompletionResponse.Choice> choices = body.getChoices();
         if (choices == null || choices.isEmpty()) {
             log.warn("No choices in response from OpenAI API");

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeMarkdownService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeMarkdownService.java
@@ -1,0 +1,57 @@
+package com.example.tech_interview_buddy.domain.service.resume;
+
+import com.example.tech_interview_buddy.domain.repository.resume.ResumeRepository;
+import com.example.tech_interview_buddy.domain.resume.Resume;
+import com.example.tech_interview_buddy.domain.service.ai.AiAdapter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ResumeMarkdownService {
+
+    private final AiAdapter aiAdapter;
+    private final ResumeRepository resumeRepository;
+
+    private static final String PROMPT_TEMPLATE = """
+            다음은 PDF에서 추출한 이력서 텍스트입니다. 이 텍스트를 마크다운 형식으로 변환해 주세요.
+
+            규칙:
+            - 원문 내용을 절대 수정, 요약, 재작성하지 마세요. 글자 하나 바꾸지 마세요.
+            - 이력서의 주요 섹션 제목(큰 구분 단위)은 ## 으로 표시
+            - 하위 제목(소속, 프로젝트명, 기관명 등)은 ### 으로 표시
+            - 글머리 목록은 - 으로 표시
+            - 번호가 있는 목록은 1. 2. 3. 으로 표시
+            - 강조되어야 할 텍스트(키워드, 기술명, 핵심 성과 등)는 **텍스트** 로 표시
+            - 페이지 번호, 반복되는 머리글/바닥글은 제거
+            - 마크다운 외의 설명이나 부연은 절대 포함하지 마세요. 변환된 마크다운만 출력하세요.
+
+            이력서 텍스트:
+            %s
+            """;
+
+    @Transactional
+    public void convertAndSave(Resume resume) {
+        String extractedText = resume.getExtractedText();
+        if (extractedText == null || extractedText.isBlank()) {
+            log.warn("No extracted text for resumeId={}, skipping markdown conversion", resume.getId());
+            return;
+        }
+
+        String prompt = PROMPT_TEMPLATE.formatted(extractedText);
+        String markdown = aiAdapter.sendPrompt(prompt, 4000);
+
+        if (markdown == null || markdown.isBlank()) {
+            log.warn("Markdown conversion returned empty for resumeId={}", resume.getId());
+            return;
+        }
+
+        resume.saveExtractedText(extractedText, markdown);
+        resumeRepository.save(resume);
+
+        log.info("Markdown conversion saved for resumeId={}", resume.getId());
+    }
+}


### PR DESCRIPTION
  ## Summary

  - 이력서 분석 완료/실패 시 알림 생성, 조회, 읽음 처리 기능 구현
  - AI 마크다운 변환 단계 추가 및 상세 응답에 extractedText/markdownText 노출
  - AI 평가 일관성을 위해 temperature 0.1로 조정, maxTokens 파라미터 추가
  - 마크다운 변환 실패 시 파이프라인 FAILED 처리로 변경

  ## Changes

  ### 알림 시스템
  - `Notification` 엔티티, 리포지토리, 생성/조회/읽음 서비스
  - 분석 성공/실패 시 자동 알림 생성
  - 알림 목록, 미읽음 카운트, 읽음 처리 API
  - 이력서 삭제 시 연관 알림 cascade 삭제
  - CORS에 PATCH 메서드 허용

  ### AI 개선
  - AI temperature 0.1로 하향
  - AiAdapter에 maxTokens 파라미터 추가
  - 마크다운 변환 파이프라인 단계 추가
  - 마크다운 변환 실패 시 critical 처리


Closes #18 
