### PR TITLE
이력서 점수화 기능 구현

### DIFF
--- a/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/resume/ResumeDetailResponse.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/resume/ResumeDetailResponse.java
@@ -27,6 +27,8 @@ public class ResumeDetailResponse {
 
     private ResumeReviewResponse review;
 
+    private ResumeScoreResponse scoring;
+
     private List<QuestionItem> questions;
 
     @Getter

--- a/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/resume/ResumeScoreResponse.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/dto/response/resume/ResumeScoreResponse.java
@@ -1,0 +1,35 @@
+package com.example.tech_interview_buddy.app.dto.response.resume;
+
+import com.example.tech_interview_buddy.domain.resume.ResumeScore;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResumeScoreResponse {
+
+    private int totalScore;
+    private int maxTotalScore;
+    private List<ScoreDetail> scores;
+
+    @Getter
+    @Builder
+    public static class ScoreDetail {
+        private String criteria;
+        private String criteriaLabel;
+        private int score;
+        private int maxScore;
+        private String comment;
+
+        public static ScoreDetail from(ResumeScore entity) {
+            return ScoreDetail.builder()
+                    .criteria(entity.getCriteria().name())
+                    .criteriaLabel(entity.getCriteria().getLabel())
+                    .score(entity.getScore())
+                    .maxScore(entity.getMaxScore())
+                    .comment(entity.getComment())
+                    .build();
+        }
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeAnalysisOrchestrator.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeAnalysisOrchestrator.java
@@ -5,6 +5,7 @@ import com.example.tech_interview_buddy.domain.resume.Resume;
 import com.example.tech_interview_buddy.app.service.notification.NotificationCreationService;
 import com.example.tech_interview_buddy.domain.service.resume.ResumeAiQuestionService;
 import com.example.tech_interview_buddy.domain.service.resume.ResumeAiReviewService;
+import com.example.tech_interview_buddy.domain.service.resume.ResumeAiScoringService;
 import com.example.tech_interview_buddy.domain.service.resume.ResumeMarkdownService;
 import java.io.InputStream;
 import java.time.LocalDateTime;
@@ -24,6 +25,7 @@ public class ResumeAnalysisOrchestrator {
     private final ResumeStorageService storageService;
     private final TextExtractionService textExtractionService;
     private final ResumeAiReviewService aiReviewService;
+    private final ResumeAiScoringService aiScoringService;
     private final ResumeAiQuestionService aiQuestionService;
     private final ResumeMarkdownService markdownService;
     private final NotificationCreationService notificationCreationService;
@@ -73,6 +75,8 @@ public class ResumeAnalysisOrchestrator {
             markdownService.convertAndSave(resume);
 
             aiReviewService.generateAndSave(resume);
+
+            aiScoringService.generateAndSave(resume);
 
             aiQuestionService.generateAndSave(resume);
 

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDeleteService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDeleteService.java
@@ -3,6 +3,7 @@ package com.example.tech_interview_buddy.app.service.resume;
 import com.example.tech_interview_buddy.domain.repository.NotificationRepository;
 import com.example.tech_interview_buddy.domain.repository.resume.ResumeQuestionRepository;
 import com.example.tech_interview_buddy.domain.repository.resume.ResumeRepository;
+import com.example.tech_interview_buddy.domain.repository.resume.ResumeScoreRepository;
 import com.example.tech_interview_buddy.domain.resume.Resume;
 import com.example.tech_interview_buddy.domain.resume.ResumeStatus;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ public class ResumeDeleteService {
 
     private final ResumeRepository resumeRepository;
     private final ResumeQuestionRepository questionRepository;
+    private final ResumeScoreRepository scoreRepository;
     private final NotificationRepository notificationRepository;
     private final ResumeStorageService storageService;
 
@@ -33,6 +35,7 @@ public class ResumeDeleteService {
         }
 
         questionRepository.deleteByResumeId(resumeId);
+        scoreRepository.deleteByResumeId(resumeId);
         notificationRepository.deleteByResumeId(resumeId);
         storageService.deleteFile(resume.getStorageKey());
         resumeRepository.delete(resume);

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDetailService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDetailService.java
@@ -51,22 +51,7 @@ public class ResumeDetailService {
 
         ResumeScoreResponse scoring = null;
         if (resume.getStatus() == ResumeStatus.DONE) {
-            List<ResumeScore> scoreEntities = scoreRepository.findByResumeId(resumeId);
-            if (!scoreEntities.isEmpty()) {
-                int totalScore = 0;
-                int maxTotalScore = 0;
-                List<ResumeScoreResponse.ScoreDetail> scoreDetails = new ArrayList<>();
-                for (ResumeScore entity : scoreEntities) {
-                    totalScore += entity.getScore();
-                    maxTotalScore += entity.getMaxScore();
-                    scoreDetails.add(ResumeScoreResponse.ScoreDetail.from(entity));
-                }
-                scoring = ResumeScoreResponse.builder()
-                        .totalScore(totalScore)
-                        .maxTotalScore(maxTotalScore)
-                        .scores(scoreDetails)
-                        .build();
-            }
+            scoring = buildScoringResponse(resumeId);
         }
 
         List<ResumeDetailResponse.QuestionItem> questions = questionRepository.findByResumeId(resumeId)
@@ -98,6 +83,28 @@ public class ResumeDetailService {
             case FAILED -> "분석에 실패했습니다. 이력서를 다시 업로드해 주세요.";
             default -> null;
         };
+    }
+
+    private ResumeScoreResponse buildScoringResponse(Long resumeId) {
+        List<ResumeScore> scoreEntities = scoreRepository.findByResumeId(resumeId);
+        if (scoreEntities.isEmpty()) {
+            return null;
+        }
+
+        int totalScore = 0;
+        int maxTotalScore = 0;
+        List<ResumeScoreResponse.ScoreDetail> scoreDetails = new ArrayList<>();
+        for (ResumeScore entity : scoreEntities) {
+            totalScore += entity.getScore();
+            maxTotalScore += entity.getMaxScore();
+            scoreDetails.add(ResumeScoreResponse.ScoreDetail.from(entity));
+        }
+
+        return ResumeScoreResponse.builder()
+                .totalScore(totalScore)
+                .maxTotalScore(maxTotalScore)
+                .scores(scoreDetails)
+                .build();
     }
 
     private ResumeReviewResponse parseReview(String reviewData, Long resumeId) {

--- a/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDetailService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/app/service/resume/ResumeDetailService.java
@@ -2,7 +2,10 @@ package com.example.tech_interview_buddy.app.service.resume;
 
 import com.example.tech_interview_buddy.app.dto.response.resume.ResumeDetailResponse;
 import com.example.tech_interview_buddy.app.dto.response.resume.ResumeReviewResponse;
+import com.example.tech_interview_buddy.app.dto.response.resume.ResumeScoreResponse;
 import com.example.tech_interview_buddy.domain.repository.resume.ResumeQuestionRepository;
+import com.example.tech_interview_buddy.domain.repository.resume.ResumeScoreRepository;
+import com.example.tech_interview_buddy.domain.resume.ResumeScore;
 import com.example.tech_interview_buddy.domain.repository.resume.ResumeRepository;
 import com.example.tech_interview_buddy.domain.resume.Resume;
 import com.example.tech_interview_buddy.domain.resume.ResumeStatus;
@@ -14,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,6 +28,7 @@ public class ResumeDetailService {
 
     private final ResumeRepository resumeRepository;
     private final ResumeQuestionRepository questionRepository;
+    private final ResumeScoreRepository scoreRepository;
     private final ResumeStorageService storageService;
     private final ObjectMapper objectMapper;
 
@@ -44,6 +49,26 @@ public class ResumeDetailService {
             review = parseReview(resume.getReviewData(), resumeId);
         }
 
+        ResumeScoreResponse scoring = null;
+        if (resume.getStatus() == ResumeStatus.DONE) {
+            List<ResumeScore> scoreEntities = scoreRepository.findByResumeId(resumeId);
+            if (!scoreEntities.isEmpty()) {
+                int totalScore = 0;
+                int maxTotalScore = 0;
+                List<ResumeScoreResponse.ScoreDetail> scoreDetails = new ArrayList<>();
+                for (ResumeScore entity : scoreEntities) {
+                    totalScore += entity.getScore();
+                    maxTotalScore += entity.getMaxScore();
+                    scoreDetails.add(ResumeScoreResponse.ScoreDetail.from(entity));
+                }
+                scoring = ResumeScoreResponse.builder()
+                        .totalScore(totalScore)
+                        .maxTotalScore(maxTotalScore)
+                        .scores(scoreDetails)
+                        .build();
+            }
+        }
+
         List<ResumeDetailResponse.QuestionItem> questions = questionRepository.findByResumeId(resumeId)
             .stream()
             .map(ResumeDetailResponse.QuestionItem::from)
@@ -62,6 +87,7 @@ public class ResumeDetailService {
             .markdownText(resume.getSummarizedText())
             .statusMessage(statusMessage)
             .review(review)
+            .scoring(scoring)
             .questions(questions)
             .build();
     }

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/repository/resume/ResumeScoreRepository.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/repository/resume/ResumeScoreRepository.java
@@ -1,0 +1,12 @@
+package com.example.tech_interview_buddy.domain.repository.resume;
+
+import com.example.tech_interview_buddy.domain.resume.ResumeScore;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeScoreRepository extends JpaRepository<ResumeScore, Long> {
+
+    List<ResumeScore> findByResumeId(Long resumeId);
+
+    void deleteByResumeId(Long resumeId);
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/resume/ResumeScore.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/resume/ResumeScore.java
@@ -1,0 +1,53 @@
+package com.example.tech_interview_buddy.domain.resume;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "resume_score")
+public class ResumeScore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "criteria", nullable = false, length = 30)
+    private ScoringCriteria criteria;
+
+    @Column(name = "score", nullable = false)
+    private int score;
+
+    @Column(name = "max_score", nullable = false)
+    private int maxScore;
+
+    @Column(name = "comment", columnDefinition = "TEXT")
+    private String comment;
+
+    @Builder
+    private ResumeScore(Resume resume, ScoringCriteria criteria, int score, int maxScore, String comment) {
+        this.resume = resume;
+        this.criteria = criteria;
+        this.score = score;
+        this.maxScore = maxScore;
+        this.comment = comment;
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/resume/ScoringCriteria.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/resume/ScoringCriteria.java
@@ -1,0 +1,16 @@
+package com.example.tech_interview_buddy.domain.resume;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ScoringCriteria {
+    TECHNICAL_SKILL_CLARITY("기술 스택 명확성"),
+    PROJECT_EXPERIENCE("프로젝트 경험"),
+    IMPACT_AND_ACHIEVEMENT("성과/임팩트"),
+    ATS_COMPATIBILITY("ATS 호환성"),
+    OVERALL_STRUCTURE("전체 구성/가독성");
+
+    private final String label;
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeAiScoringException.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeAiScoringException.java
@@ -1,0 +1,12 @@
+package com.example.tech_interview_buddy.domain.service.resume;
+
+public class ResumeAiScoringException extends RuntimeException {
+
+    public ResumeAiScoringException(String message) {
+        super(message);
+    }
+
+    public ResumeAiScoringException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeAiScoringService.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeAiScoringService.java
@@ -1,0 +1,119 @@
+package com.example.tech_interview_buddy.domain.service.resume;
+
+import com.example.tech_interview_buddy.domain.repository.resume.ResumeScoreRepository;
+import com.example.tech_interview_buddy.domain.resume.Resume;
+import com.example.tech_interview_buddy.domain.resume.ResumeScore;
+import com.example.tech_interview_buddy.domain.resume.ScoringCriteria;
+import com.example.tech_interview_buddy.domain.service.ai.AiAdapter;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ResumeAiScoringService {
+
+    private final AiAdapter aiAdapter;
+    private final ResumeScoringPromptTemplate promptTemplate;
+    private final ObjectMapper objectMapper;
+    private final ResumeScoreRepository scoreRepository;
+
+    @Transactional
+    public void generateAndSave(Resume resume) {
+        String text = resume.getExtractedText();
+
+        List<ScoreItem> scores = callWithRetry(text);
+        if (scores == null || scores.isEmpty()) {
+            log.warn("AI returned no scores for resumeId={}", resume.getId());
+            return;
+        }
+
+        List<ResumeScore> entities = scores.stream()
+                .map(item -> ResumeScore.builder()
+                        .resume(resume)
+                        .criteria(parseCriteria(item.getCriteria()))
+                        .score(clampScore(item.getScore()))
+                        .maxScore(10)
+                        .comment(item.getComment())
+                        .build())
+                .collect(Collectors.toList());
+
+        scoreRepository.saveAll(entities);
+        log.info("Saved {} scores for resumeId={}", entities.size(), resume.getId());
+    }
+
+    private List<ScoreItem> callWithRetry(String resumeText) {
+        String prompt = promptTemplate.buildPrompt(resumeText);
+
+        String rawResponse = aiAdapter.sendPrompt(prompt);
+        List<ScoreItem> scores = tryParse(rawResponse);
+
+        if (scores != null) {
+            return scores;
+        }
+
+        log.warn("AI scoring parse failed on first attempt, retrying...");
+        rawResponse = aiAdapter.sendPrompt(prompt);
+        scores = tryParse(rawResponse);
+
+        if (scores != null) {
+            return scores;
+        }
+
+        throw new ResumeAiScoringException("AI 점수 평가 응답을 파싱하는 데 실패했습니다.");
+    }
+
+    private List<ScoreItem> tryParse(String rawResponse) {
+        if (rawResponse == null || rawResponse.isBlank()) {
+            return null;
+        }
+        try {
+            String json = extractJsonArray(rawResponse);
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            log.warn("Failed to parse AI scoring response: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private String extractJsonArray(String raw) {
+        int start = raw.indexOf('[');
+        int end = raw.lastIndexOf(']');
+        if (start == -1 || end == -1 || start >= end) {
+            return raw;
+        }
+        return raw.substring(start, end + 1);
+    }
+
+    private ScoringCriteria parseCriteria(String value) {
+        try {
+            return ScoringCriteria.valueOf(value);
+        } catch (Exception e) {
+            log.warn("Unknown scoring criteria '{}', defaulting to OVERALL_STRUCTURE", value);
+            return ScoringCriteria.OVERALL_STRUCTURE;
+        }
+    }
+
+    private int clampScore(int score) {
+        return Math.max(0, Math.min(10, score));
+    }
+
+    @Getter
+    @Builder
+    @Jacksonized
+    static class ScoreItem {
+        private String criteria;
+        private int score;
+        private int maxScore;
+        private String comment;
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeQuestionPromptTemplate.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeQuestionPromptTemplate.java
@@ -60,13 +60,7 @@ public class ResumeQuestionPromptTemplate {
         """;
 
     public String buildPrompt(String resumeText) {
-        return String.format("""
-            %s
-
-            ### 이력서 내용
-            %s
-
-            위 이력서를 분석하여 위에서 정의한 JSON 배열 형식으로만 응답하세요.
-            """, SYSTEM_INSTRUCTION, resumeText);
+        return SYSTEM_INSTRUCTION + "\n\n### 이력서 내용\n" + resumeText
+                + "\n\n위 이력서를 분석하여 위에서 정의한 JSON 배열 형식으로만 응답하세요.\n";
     }
 }

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeReviewPromptTemplate.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeReviewPromptTemplate.java
@@ -62,13 +62,7 @@ public class ResumeReviewPromptTemplate {
         """;
 
     public String buildPrompt(String resumeText) {
-        return String.format("""
-            %s
-
-            ### 이력서 내용
-            %s
-
-            위 이력서를 분석하여 위에서 정의한 JSON 형식으로만 응답하세요.
-            """, SYSTEM_INSTRUCTION, resumeText);
+        return SYSTEM_INSTRUCTION + "\n\n### 이력서 내용\n" + resumeText
+                + "\n\n위 이력서를 분석하여 위에서 정의한 JSON 형식으로만 응답하세요.\n";
     }
 }

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeScoringPromptTemplate.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeScoringPromptTemplate.java
@@ -1,0 +1,55 @@
+package com.example.tech_interview_buddy.domain.service.resume;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ResumeScoringPromptTemplate {
+
+    private static final String SYSTEM_INSTRUCTION = """
+        당신은 10년 이상의 채용 경험을 가진 시니어 개발자이자 기술 면접관입니다.
+        지원자의 이력서를 꼼꼼히 읽고, 5개 평가 항목별로 점수를 부여해야 합니다.
+
+        ### 평가 항목 (각 항목 10점 만점)
+        1. TECHNICAL_SKILL_CLARITY — 기술 스택 명확성: 사용 기술이 명확하고 구체적으로 기술되어 있는가
+        2. PROJECT_EXPERIENCE — 프로젝트 경험: 프로젝트 설명이 충분하고 역할/기여가 명확한가
+        3. IMPACT_AND_ACHIEVEMENT — 성과/임팩트: 정량적 성과나 비즈니스 임팩트가 기술되어 있는가
+        4. ATS_COMPATIBILITY — ATS 호환성: 키워드, 형식, 구조가 ATS 시스템에 적합한가
+        5. OVERALL_STRUCTURE — 전체 구성/가독성: 이력서의 전체 구성과 가독성이 우수한가
+
+        ### 점수 루브릭
+        - 1~3점: 부족 — 해당 항목이 거의 다루어지지 않았거나 심각한 개선이 필요
+        - 4~6점: 보통 — 기본적인 내용은 있으나 구체성이나 완성도가 부족
+        - 7~9점: 우수 — 잘 작성되어 있으며 구체적이고 설득력 있음
+        - 10점: 탁월 — 해당 항목에서 거의 완벽한 수준
+
+        ### 출력 형식
+        반드시 아래 JSON 배열만 출력하세요. 설명, 마크다운 코드 블록, 기타 텍스트는 포함하지 마세요.
+
+        [
+          {"criteria":"TECHNICAL_SKILL_CLARITY","score":8,"maxScore":10,"comment":"기술 스택이 명확하게 기술되어 있습니다."},
+          {"criteria":"PROJECT_EXPERIENCE","score":7,"maxScore":10,"comment":"프로젝트 경험이 구체적입니다."},
+          {"criteria":"IMPACT_AND_ACHIEVEMENT","score":5,"maxScore":10,"comment":"정량적 성과가 부족합니다."},
+          {"criteria":"ATS_COMPATIBILITY","score":6,"maxScore":10,"comment":"키워드는 포함되어 있으나 형식 개선이 필요합니다."},
+          {"criteria":"OVERALL_STRUCTURE","score":7,"maxScore":10,"comment":"전체적인 구성이 깔끔합니다."}
+        ]
+
+        ### 응답 규칙
+        - 반드시 한국어로 comment를 작성하세요.
+        - 5개 항목 모두 빠짐없이 포함해야 합니다.
+        - criteria 값은 반드시 위에서 정의한 영문 코드명을 그대로 사용하세요.
+        - maxScore는 항상 10입니다.
+        - score는 1 이상 10 이하의 정수입니다.
+        - comment는 해당 점수를 부여한 근거를 1~2문장으로 작성하세요.
+        """;
+
+    public String buildPrompt(String resumeText) {
+        return String.format("""
+            %s
+
+            ### 이력서 내용
+            %s
+
+            위 이력서를 분석하여 위에서 정의한 JSON 배열 형식으로만 응답하세요.
+            """, SYSTEM_INSTRUCTION, resumeText);
+    }
+}

--- a/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeScoringPromptTemplate.java
+++ b/app/src/main/java/com/example/tech_interview_buddy/domain/service/resume/ResumeScoringPromptTemplate.java
@@ -43,13 +43,7 @@ public class ResumeScoringPromptTemplate {
         """;
 
     public String buildPrompt(String resumeText) {
-        return String.format("""
-            %s
-
-            ### 이력서 내용
-            %s
-
-            위 이력서를 분석하여 위에서 정의한 JSON 배열 형식으로만 응답하세요.
-            """, SYSTEM_INSTRUCTION, resumeText);
+        return SYSTEM_INSTRUCTION + "\n\n### 이력서 내용\n" + resumeText
+                + "\n\n위 이력서를 분석하여 위에서 정의한 JSON 배열 형식으로만 응답하세요.\n";
     }
 }

--- a/app/src/test/groovy/com/example/tech_interview_buddy/domain/service/resume/ResumeAiScoringServiceSpec.groovy
+++ b/app/src/test/groovy/com/example/tech_interview_buddy/domain/service/resume/ResumeAiScoringServiceSpec.groovy
@@ -1,0 +1,185 @@
+package com.example.tech_interview_buddy.domain.service.resume
+
+import com.example.tech_interview_buddy.domain.repository.resume.ResumeScoreRepository
+import com.example.tech_interview_buddy.domain.resume.Resume
+import com.example.tech_interview_buddy.domain.resume.ResumeScore
+import com.example.tech_interview_buddy.domain.resume.ScoringCriteria
+import com.example.tech_interview_buddy.domain.service.ai.AiAdapter
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Specification
+import spock.lang.Subject
+
+class ResumeAiScoringServiceSpec extends Specification {
+
+    AiAdapter aiAdapter = Mock()
+    ResumeScoringPromptTemplate promptTemplate = Mock()
+    ResumeScoreRepository scoreRepository = Mock()
+    ObjectMapper objectMapper = new ObjectMapper()
+
+    @Subject
+    ResumeAiScoringService service = new ResumeAiScoringService(
+            aiAdapter, promptTemplate, objectMapper, scoreRepository
+    )
+
+    static final String VALID_JSON = """
+        [
+          {"criteria":"TECHNICAL_SKILL_CLARITY","score":8,"maxScore":10,"comment":"기술 스택이 명확합니다."},
+          {"criteria":"PROJECT_EXPERIENCE","score":7,"maxScore":10,"comment":"프로젝트 경험이 구체적입니다."},
+          {"criteria":"IMPACT_AND_ACHIEVEMENT","score":5,"maxScore":10,"comment":"정량적 성과가 부족합니다."},
+          {"criteria":"ATS_COMPATIBILITY","score":6,"maxScore":10,"comment":"키워드는 포함되어 있습니다."},
+          {"criteria":"OVERALL_STRUCTURE","score":7,"maxScore":10,"comment":"전체적인 구성이 깔끔합니다."}
+        ]
+    """
+
+    def makeResume(String extractedText = "이력서 본문") {
+        def resume = Mock(Resume)
+        resume.getId() >> 1L
+        resume.getExtractedText() >> extractedText
+        return resume
+    }
+
+    // === generateAndSave 성공 케이스 ===
+
+    def "AI가 유효한 JSON을 반환하면 파싱 후 점수를 저장한다"() {
+        given:
+        def resume = makeResume()
+        promptTemplate.buildPrompt(_) >> "prompt"
+        aiAdapter.sendPrompt(_) >> VALID_JSON
+
+        when:
+        service.generateAndSave(resume)
+
+        then:
+        1 * scoreRepository.saveAll({ List<ResumeScore> scores ->
+            scores.size() == 5 &&
+            scores[0].criteria == ScoringCriteria.TECHNICAL_SKILL_CLARITY &&
+            scores[0].score == 8 &&
+            scores[1].criteria == ScoringCriteria.PROJECT_EXPERIENCE &&
+            scores[1].score == 7 &&
+            scores[2].criteria == ScoringCriteria.IMPACT_AND_ACHIEVEMENT &&
+            scores[2].score == 5 &&
+            scores[3].criteria == ScoringCriteria.ATS_COMPATIBILITY &&
+            scores[3].score == 6 &&
+            scores[4].criteria == ScoringCriteria.OVERALL_STRUCTURE &&
+            scores[4].score == 7
+        })
+    }
+
+    def "extractedText를 프롬프트에 사용한다"() {
+        given:
+        def resume = makeResume("이력서 본문 텍스트")
+        promptTemplate.buildPrompt("이력서 본문 텍스트") >> "prompt"
+        aiAdapter.sendPrompt(_) >> VALID_JSON
+
+        when:
+        service.generateAndSave(resume)
+
+        then:
+        1 * promptTemplate.buildPrompt("이력서 본문 텍스트")
+    }
+
+    // === 재시도 케이스 ===
+
+    def "첫 번째 AI 응답 파싱 실패 시 1회 재시도 후 성공하면 저장한다"() {
+        given:
+        def resume = makeResume()
+        promptTemplate.buildPrompt(_) >> "prompt"
+
+        when:
+        service.generateAndSave(resume)
+
+        then:
+        2 * aiAdapter.sendPrompt(_) >>> ["invalid json", VALID_JSON]
+        1 * scoreRepository.saveAll(_)
+    }
+
+    def "AI 응답이 null일 때 1회 재시도 후 성공하면 저장한다"() {
+        given:
+        def resume = makeResume()
+        promptTemplate.buildPrompt(_) >> "prompt"
+
+        when:
+        service.generateAndSave(resume)
+
+        then:
+        2 * aiAdapter.sendPrompt(_) >>> [null, VALID_JSON]
+        1 * scoreRepository.saveAll(_)
+    }
+
+    // === 실패 케이스 ===
+
+    def "두 번 모두 파싱 실패하면 ResumeAiScoringException을 던진다"() {
+        given:
+        def resume = makeResume()
+        promptTemplate.buildPrompt(_) >> "prompt"
+        aiAdapter.sendPrompt(_) >> "invalid json"
+
+        when:
+        service.generateAndSave(resume)
+
+        then:
+        thrown(ResumeAiScoringException)
+        2 * aiAdapter.sendPrompt(_)
+        0 * scoreRepository.saveAll(_)
+    }
+
+    def "두 번 모두 null 응답이면 ResumeAiScoringException을 던진다"() {
+        given:
+        def resume = makeResume()
+        promptTemplate.buildPrompt(_) >> "prompt"
+        aiAdapter.sendPrompt(_) >> null
+
+        when:
+        service.generateAndSave(resume)
+
+        then:
+        thrown(ResumeAiScoringException)
+        2 * aiAdapter.sendPrompt(_)
+    }
+
+    // === 점수 범위 검증 ===
+
+    def "점수가 0-10 범위를 벗어나면 클램핑된다"() {
+        given:
+        def resume = makeResume()
+        promptTemplate.buildPrompt(_) >> "prompt"
+        aiAdapter.sendPrompt(_) >> """
+            [
+              {"criteria":"TECHNICAL_SKILL_CLARITY","score":-1,"maxScore":10,"comment":"테스트"},
+              {"criteria":"PROJECT_EXPERIENCE","score":15,"maxScore":10,"comment":"테스트"},
+              {"criteria":"IMPACT_AND_ACHIEVEMENT","score":5,"maxScore":10,"comment":"테스트"},
+              {"criteria":"ATS_COMPATIBILITY","score":0,"maxScore":10,"comment":"테스트"},
+              {"criteria":"OVERALL_STRUCTURE","score":10,"maxScore":10,"comment":"테스트"}
+            ]
+        """
+
+        when:
+        service.generateAndSave(resume)
+
+        then:
+        1 * scoreRepository.saveAll({ List<ResumeScore> scores ->
+            scores[0].score == 0 &&
+            scores[1].score == 10 &&
+            scores[2].score == 5 &&
+            scores[3].score == 0 &&
+            scores[4].score == 10
+        })
+    }
+
+    // === 마크다운 래핑 처리 ===
+
+    def "JSON 앞뒤에 마크다운 코드블록이 있어도 파싱에 성공한다"() {
+        given:
+        def resume = makeResume()
+        promptTemplate.buildPrompt(_) >> "prompt"
+        aiAdapter.sendPrompt(_) >> "```json\n${VALID_JSON}\n```"
+
+        when:
+        service.generateAndSave(resume)
+
+        then:
+        1 * scoreRepository.saveAll({ List<ResumeScore> scores ->
+            scores.size() == 5
+        })
+    }
+}


### PR DESCRIPTION
  ## Summary

  - 이력서 AI 평가 점수화 기능 추가: 5개 항목(기술스택, 프로젝트경험, 성과/임팩트, ATS호환성, 전체구성) × 10점 만점
  - 이력서 상세 API 응답에 `scoring` 필드 추가 (항목별 점수 + 총점 + AI 코멘트)
  - 분석 파이프라인에 점수 평가 단계 삽입 (리뷰 → 점수 → 질문)
  - 대시보드에 recharts 레이더차트로 점수 시각화

  ## Changes

  ### 도메인 모델
  - `ScoringCriteria` enum: 5개 평가 항목 + 한국어 label
  - `ResumeScore` 엔티티: resume_score 테이블 (ManyToOne Resume)
  - `ResumeScoreRepository`: 조회/삭제

  ### AI 점수 생성
  - `ResumeScoringPromptTemplate`: 점수 루브릭 포함 AI 프롬프트
  - `ResumeAiScoringService`: AI 호출 → JSON 파싱 → 저장 (1회 재시도, 0-10 클램핑)
  - `ResumeAiScoringException`: 2회 파싱 실패 시 예외

  ### API 통합
  - `ResumeScoreResponse` DTO: totalScore, maxTotalScore, scores[]
  - `ResumeDetailResponse`에 scoring 필드 추가
  - `ResumeDetailService`: DONE 상태 시 점수 조회 및 응답 조립
  - `ResumeDeleteService`: 이력서 삭제 시 점수 cascade 삭제
  - `ResumeAnalysisOrchestrator`: 리뷰 → 점수 → 질문 순서로 실행


Closes #19 